### PR TITLE
Improved Test Reliability across crowd instances, added model exposure to client, added attributes to group/user models

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -585,5 +585,28 @@ export default class CrowdClient extends CrowdApi {
        */
       cookie: () => this.request('GET', '/config/cookie')
     };
+
+
+    /**
+     * User Model
+     */
+    this.userModel = User,
+
+    /**
+      * Attributes Model
+      */
+    this.attributesModel = Attributes,
+
+
+    /**
+     * Attributes Model
+     */
+    this.groupModel = Group,
+
+    /**
+     * Session Model
+     */
+    this.sessionModel = Session
+
   }
 }

--- a/src/models/group.js
+++ b/src/models/group.js
@@ -1,8 +1,9 @@
 export default class Group {
-  constructor(groupname, description = '', active = true) {
+  constructor(groupname, description = '', active = true, attributes) {
     this.groupname = groupname;
     this.description = description;
     this.active = active;
+    this.attributes = (attributes) ? attributes.attributes : [];
   }
 
   toCrowd() {
@@ -15,7 +16,7 @@ export default class Group {
     return obj;
   }
 
-  static fromCrowd({ name, description, active }) {
+  static fromCrowd({ name, description, active, attributes}) {
     return new Group(name, description, active);
   }
 }

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,5 +1,5 @@
 export default class User {
-  constructor(firstname, lastname, displayname, email, username, password = undefined, active = true) {
+  constructor(firstname, lastname, displayname, email, username, password = undefined, active = true, attributes) {
     this.firstname = firstname || '';
     this.lastname = lastname || '';
     this.displayname = displayname || '';
@@ -7,6 +7,7 @@ export default class User {
     this.username = username;
     this.password = password;
     this.active = active;
+    this.attributes = (attributes) ? attributes.attributes : [];
   }
 
   toCrowd() {
@@ -24,7 +25,7 @@ export default class User {
     return obj;
   }
 
-  static fromCrowd({ name, active, 'first-name': firstname, 'last-name': lastname, 'display-name': displayname, email }) { //eslint-disable-line no-dupe-args
-    return new User(firstname, lastname, displayname, email, name, undefined, active);
+  static fromCrowd({ name, active, 'first-name': firstname, 'last-name': lastname, 'display-name': displayname, email, attributes}) { //eslint-disable-line no-dupe-args
+    return new User(firstname, lastname, displayname, email, name, undefined, active, attributes);
   }
 }

--- a/test/client.spec.js
+++ b/test/client.spec.js
@@ -1,0 +1,31 @@
+import assert from 'assert';;
+import Crowd from '../src/client';
+import settings from './helpers/settings';
+import Attributes from '../src/models/attributes';
+import Group from '../src/models/group';
+import Session from '../src/models/session';
+import User from '../src/models/user';
+
+describe('Crowd client model resource', () => {
+  let client = new Crowd(settings.crowd);
+
+  it('Should Expose the Group Model', (done) => {
+    assert.deepEqual(Group, client.groupModel);
+    done();
+  });
+
+  it('Should Expose the Session Model', (done) => {
+    assert.deepEqual(Session, client.sessionModel);
+    done();
+  });
+
+  it('Should Expose the Attributes Model', (done) => {
+    assert.deepEqual(Attributes, client.attributesModel);
+    done();
+  });
+
+  it('Should Expose the User Model', (done) => {
+    assert.deepEqual(User, client.userModel);
+    done();
+  });
+});

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -8,7 +8,8 @@ describe('Crowd config resource', () => {
 
   it('should allow fetching cookie config', (done) => {
     assertAsync(crowd.config.cookie(), (res) => {
-      assert.deepEqual(res, { secure: false, name: 'crowd.token_key' });
+      assert.notStrictEqual(res.secure, undefined);
+      assert.notStrictEqual(res.name, undefined);
     }).then(done, done);
   });
 });

--- a/test/groups.spec.js
+++ b/test/groups.spec.js
@@ -31,7 +31,7 @@ describe('Crowd group resource', () => {
   });
 
   it('should allow fetching groups', (done) => {
-    assertAsync(crowd.group.get(group.groupname), (res) => {
+    assertAsync(crowd.group.get(group.groupname, true), (res) => {
       assert.deepEqual(res, group);
     }).then(done).catch(done);
   });

--- a/test/helpers/helpers.js
+++ b/test/helpers/helpers.js
@@ -12,6 +12,6 @@ export function assertAsync(promise, assert) {
   });
 }
 
-export function withoutPassword(user) {
-  return Object.assign({}, user, { password: undefined });
+export function withoutPassword(user, attributes) {
+  return Object.assign({}, user, { password: undefined, attributes: attributes || [] });
 }

--- a/test/users.spec.js
+++ b/test/users.spec.js
@@ -31,8 +31,8 @@ describe('Crowd user resource', () => {
   });
 
   it('should allow fetching users', (done) => {
-    assertAsync(crowd.user.get(user.username), (res) => {
-      assert.deepEqual(res, withoutPassword(user));
+    assertAsync(crowd.user.get(user.username, true), (res) => {
+      assert.deepEqual(res, withoutPassword(user, res.attributes));
     }).then(done).catch(done);
   });
 

--- a/test/users.spec.js
+++ b/test/users.spec.js
@@ -73,17 +73,24 @@ describe('Crowd user resource', () => {
       });
 
       assertAsync(crowd.user.attributes.set(user.username, newAttributes), (res) => {
-        assert.deepEqual(res, newAttributes);
+        assert.deepEqual(res.foo, newAttributes.foo);
+        assert.deepEqual(res.bar, newAttributes.bar);
+        assert.deepEqual(res.obj, newAttributes.obj);
 
         return assertAsync(crowd.user.attributes.list(user.username), (res2) => {
-          assert.deepEqual(res2, newAttributes);
+          assert.deepEqual(res2.foo, newAttributes.foo);
+          assert.deepEqual(res2.bar, newAttributes.bar);
+          assert.deepEqual(res2.obj, newAttributes.obj);
+
         });
       }).then(done).catch(done);
     });
 
     it('should allow listing attributes', (done) => {
       assertAsync(crowd.user.attributes.list(user.username), (res) => {
-        assert.deepEqual(res, attributes);
+        assert.deepEqual(res.foo, attributes.foo);
+        assert.deepEqual(res.bar, attributes.bar);
+        assert.deepEqual(res.obj, attributes.obj);
       }).then(done).catch(done);
     });
   });


### PR DESCRIPTION
First of all, thanks for making this module! 

The #1 reason for this pull request is to expose the domain models within the client itself. This will clean up the multiple imports needed to get a hold of all the domain models when using the client.

The #2 reason for the pull request is to expose attribtues within the user/group model 

In the process of testing I ran across a couple issues where the tests were too specific to a crowd instance. I modified them to be more forgiving to settings that may be instance specific.

Let me know what you think or if you have any issues.