### PR TITLE
Passing withAttributes value through so that attributes for Groups can be retrieved in a single call.

### DIFF
--- a/src/models/group.js
+++ b/src/models/group.js
@@ -17,6 +17,6 @@ export default class Group {
   }
 
   static fromCrowd({ name, description, active, attributes}) {
-    return new Group(name, description, active);
+    return new Group(name, description, active, attributes);
   }
 }

--- a/test/groups.spec.js
+++ b/test/groups.spec.js
@@ -87,6 +87,13 @@ describe('Crowd group resource', () => {
       }).then(done).catch(done);
     });
 
+    it('should allow for the return of attributes when group withAttributes value is set to true', (done) => {
+      var withAttributes = true;
+      assertAsync(crowd.group.get(group.groupname, withAttributes), (res) => {
+        assert.deepEqual(Attributes.fromCrowd(res.attributes), attributes);
+      }).then(done).catch(done);
+    });
+
     it('should reject large attribute values', (done) => {
       let largeAttributes = new Attributes({
         foo: 'Aliquam laoreet ultricies neque, non sollicitudin diam euismod et. Suspendisse volutpat et velit quis scelerisque. Sed elit diam, accumsan ut facilisis id, gravida in justo. Maecenas dolor dolor, volutpat vel nunc eget, vehicula convallis lorem. Praelol',


### PR DESCRIPTION
This fix should address this issue:
https://github.com/wehkamp/atlassian-crowd-client/issues/6

I wrote a test condition to ensure this is working.

This is my first contribution to a public Git Hub project, so please let me know if I'm doing anything that isn't best practice.
